### PR TITLE
💥 period in schedules no longer uses year.

### DIFF
--- a/corrai/tsgenerator.py
+++ b/corrai/tsgenerator.py
@@ -1,6 +1,7 @@
-import pandas as pd
-import numpy as np
+import datetime as dt
 
+import numpy as np
+import pandas as pd
 from numpy.random import MT19937
 from numpy.random import RandomState, SeedSequence
 
@@ -903,9 +904,9 @@ class Scheduler:
                     ...
                 },
                 "PERIODS": [
-                    (("2009-01-01", "2009-03-31"), "winter_week"),
-                    (("2009-04-01", "2009-09-30"), "summer_week"),
-                    (("2009-10-01", "2009-12-31"), "winter_week"),
+                    (("01-01", "03-31"), "winter_week"),
+                    (("04-01", "09-30"), "summer_week"),
+                    (("10-01", "12-31"), "winter_week"),
                 ],
                 "TZ": "Europe/Paris",
             }
@@ -962,19 +963,23 @@ class Scheduler:
 
         return day_dict
 
-    def get_dataframe(self, freq="T"):
+    def get_full_year_time_series(self, year=None, freq="T"):
         """
         Generates and returns the scheduled DataFrame based on the configuration
         settings.
 
+        :param year: Year to generate the time series for. Default is current year
         :param str freq: output DataFrame DateTimeIndex frequency
         """
+
+        if year is None:
+            year = dt.datetime.now().year
 
         day_list = []
         for period in self.config_dict["PERIODS"]:
             period_index = pd.date_range(
-                start=period[0][0],
-                end=period[0][1],
+                start=f"{str(year)}-{period[0][0]}",
+                end=f"{str(year)}-{period[0][1]}",
                 freq="D",
                 tz=self.config_dict["TZ"],
             )

--- a/tests/test_tsgenerator.py
+++ b/tests/test_tsgenerator.py
@@ -191,9 +191,9 @@ class TestDomesticWaterConsumption:
                 },
             },
             "PERIODS": [
-                (("2009-01-01", "2009-03-31"), "winter_week"),
-                (("2009-04-01", "2009-09-30"), "summer_week"),
-                (("2009-10-01", "2009-12-31"), "winter_week"),
+                (("01-01", "03-31"), "winter_week"),
+                (("04-01", "09-30"), "summer_week"),
+                (("10-01", "12-31"), "winter_week"),
             ],
             "TZ": "Europe/Paris",
         }
@@ -208,6 +208,6 @@ class TestDomesticWaterConsumption:
 
         sched = Scheduler(config_dict=schedule_dict)
 
-        df = sched.get_dataframe(freq="H")
+        df = sched.get_full_year_time_series(freq="H", year=2009)
 
         pd.testing.assert_frame_equal(df, ref)


### PR DESCRIPTION
get dataframe refactored to get_full_year_time_series